### PR TITLE
Allow the adjustment of the spacing width

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,12 @@ Now you have a "hello world" block in the lower right segment of your prompt! So
 :warning: **Note:** there may be some spacing issues in the upper segments when using multiline mode.
 To solve this, try wrapping variables (especially color variables, e.g. `$fg[...]`) within `%{…%}`
 (see [this link](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Visual-effects) for
-more details).
+more details).  If the error is consistent, you can adjust the spacing:
+
+| Variable | Default | Meaning |
+| :------- | :------ | :------ |
+| `BLOX_SEG__ADJUST_SPACING_WIDTH` | `0` | Will be added to the calculated spacing length 
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ more details).  If the error is consistent, you can adjust the spacing:
 
 | Variable | Default | Meaning |
 | :------- | :------ | :------ |
-| `BLOX_SEG__ADJUST_SPACING_WIDTH` | `0` | Will be added to the calculated spacing length 
+| `BLOX_SEG__ADJUST_SPACING_WIDTH` | `0` | Will be subtracted from the calculated spacing length 
 
 
 ---

--- a/src/render.zsh
+++ b/src/render.zsh
@@ -20,7 +20,7 @@ function blox_helper__calculate_spaces() {
 
   # Desired spaces length
   local termwidth
-  (( termwidth = ${COLUMNS} - ${left} - ${right} ))
+  (( termwidth = ${COLUMNS} - ${left} - ${right} - ${BLOX_CONF__ADJUST_SEGMENT_SPACING:-0}))
 
   # Calculate spaces
   local spacing=""

--- a/src/render.zsh
+++ b/src/render.zsh
@@ -20,7 +20,7 @@ function blox_helper__calculate_spaces() {
 
   # Desired spaces length
   local termwidth
-  (( termwidth = ${COLUMNS} - ${left} - ${right} - ${BLOX_CONF__ADJUST_SEGMENT_SPACING:-0}))
+  (( termwidth = ${COLUMNS} - ${left} - ${right} - ${BLOX_SEG__ADJUST_SPACING_WIDTH:-0}))
 
   # Calculate spaces
   local spacing=""


### PR DESCRIPTION
Allow the spacing between $left and $right to be adjusted via a  variable.  The reason is that the spacing is off by one in my libvterm embedded terminal in emacs; $right will overflow and occupy to lines.  If I set BLOX_CONF__ADJUST_SEGMENT_SPACING to 1, everything is fine.